### PR TITLE
Replace #!/bin/bash with #!/usr/bin/env bash

### DIFF
--- a/3rd/avs-device-sdk/mac/include/Audio/Data/create_header.bash
+++ b/3rd/avs-device-sdk/mac/include/Audio/Data/create_header.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This is used to create a header file that contains binary data from a file that can be used in this library.  The
 # files are downloaded from https://developer.amazon.com/docs/alexa-voice-service/ux-design-overview.html#sounds.

--- a/3rd/avs-device-sdk/vicos/include/Audio/Data/create_header.bash
+++ b/3rd/avs-device-sdk/vicos/include/Audio/Data/create_header.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This is used to create a header file that contains binary data from a file that can be used in this library.  The
 # files are downloaded from https://developer.amazon.com/docs/alexa-voice-service/ux-design-overview.html#sounds.

--- a/3rd/opencv/modules/core/src/opencl/runtime/generator/generate.sh
+++ b/3rd/opencv/modules/core/src/opencl/runtime/generator/generate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 echo "Generate files for CL runtime..."
 python parser_cl.py opencl_core < sources/cl.h
 python parser_cl.py opencl_gl < sources/cl_gl.h

--- a/3rd/picovoice/x86_64-linux/create-model.sh
+++ b/3rd/picovoice/x86_64-linux/create-model.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ ! -d oldpork ]]; then
 	wget https://archive.org/download/github.com-Picovoice-Porcupine_-_2018-10-07_02-31-11/Picovoice-Porcupine_-_2018-10-07_02-31-11.bundle

--- a/build/actions.sh
+++ b/build/actions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/build/bd.sh
+++ b/build/bd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/build/build-v.sh
+++ b/build/build-v.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/build/cbd.sh
+++ b/build/cbd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/build/clean.sh
+++ b/build/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ ! -f ./CPPLINT.cfg ]]; then
     if [[ -f ../CPPLINT.cfg ]]; then

--- a/build/deploy-v.sh
+++ b/build/deploy-v.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
 echo $DIR

--- a/coretech/planning/tools/perf.sh
+++ b/coretech/planning/tools/perf.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This is a script which runs through a set of environments in the standalone planner to look at the
 # performance

--- a/lib/audio/build-scripts/create-audio-assets-pr.sh
+++ b/lib/audio/build-scripts/create-audio-assets-pr.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Get latest SVN revision from project's generated sound bank svn repo, open Pull-Request for new clad files
 #

--- a/lib/audio/gyp/configure.sh
+++ b/lib/audio/gyp/configure.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function arg_help() {
   echo "Usage: $0 [-h] [-p {ios/mac}] [-f OUTPUT_DIR] "

--- a/lib/audio/gyp/decompressAudioLibs.sh
+++ b/lib/audio/gyp/decompressAudioLibs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SRCDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 

--- a/lib/audio/tools/WWiseGenerateSoundBanks.sh
+++ b/lib/audio/tools/WWiseGenerateSoundBanks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This scrip will generate sound banks and Tar them to the SVN folder.
 # I'm assuming the WWise Application is in the Application folder.

--- a/lib/audio/tools/build-android.sh
+++ b/lib/audio/tools/build-android.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/lib/audio/tools/compressAudioLibs.sh
+++ b/lib/audio/tools/compressAudioLibs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SRCDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 

--- a/lib/audio/tools/copyWWiseSDKsIntoProject.sh
+++ b/lib/audio/tools/copyWWiseSDKsIntoProject.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This scrip will copy and configure  Wwise include headers and SDK files
 # needed for Mac OS X, iOS and Android platforms. Pass the platform include

--- a/lib/audio/tools/printGypLibStr.sh
+++ b/lib/audio/tools/printGypLibStr.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 MAC_IOS_LIB_DIR=$1
 ANDROID_LIB_DIR=$2

--- a/lib/audio/wwise/clean-wwise-unused-libs.sh
+++ b/lib/audio/wwise/clean-wwise-unused-libs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -u

--- a/lib/audio/wwise/fetch-wwise.sh
+++ b/lib/audio/wwise/fetch-wwise.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -u

--- a/lib/das-client/testing/gtest/xcode/Samples/FrameworkSample/runtests.sh
+++ b/lib/das-client/testing/gtest/xcode/Samples/FrameworkSample/runtests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2008, Google Inc.
 # All rights reserved.

--- a/lib/das-client/testing/gtest/xcode/Scripts/runtests.sh
+++ b/lib/das-client/testing/gtest/xcode/Scripts/runtests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2008, Google Inc.
 # All rights reserved.

--- a/lib/das-client/tools/buildAll.sh
+++ b/lib/das-client/tools/buildAll.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -u

--- a/lib/util/project/buildServer/buildIosArtifacts.sh
+++ b/lib/util/project/buildServer/buildIosArtifacts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 BUILDDIR=$1
 UNITTEST=$2

--- a/lib/util/project/buildServer/continuousIntegration.sh
+++ b/lib/util/project/buildServer/continuousIntegration.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 BUILDDIR=$1
 UNITTEST=$2

--- a/lib/util/project/buildServer/steps/clean.sh
+++ b/lib/util/project/buildServer/steps/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2014 Anki, Inc.
 # All rights reserved.
 set -e

--- a/lib/util/project/buildServer/steps/configure.sh
+++ b/lib/util/project/buildServer/steps/configure.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2014 Anki, Inc.
 # All rights reserved.
 set -e

--- a/lib/util/project/buildServer/steps/scanBuild.sh
+++ b/lib/util/project/buildServer/steps/scanBuild.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # change dir to the project dir, no matter where script is executed from
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/lib/util/project/buildServer/steps/sonarQube.sh
+++ b/lib/util/project/buildServer/steps/sonarQube.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # change dir to the project dir, no matter where script is executed from
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/lib/util/project/buildServer/steps/sonarQubeIncremental.sh
+++ b/lib/util/project/buildServer/steps/sonarQubeIncremental.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PR_NUMBER=$1
 

--- a/lib/util/source/3rd/civetweb/ci/travis/install_rocks.sh
+++ b/lib/util/source/3rd/civetweb/ci/travis/install_rocks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ev
 
 source ci/travis/lua_env.sh

--- a/lib/util/source/3rd/civetweb/ci/travis/lua_env.sh
+++ b/lib/util/source/3rd/civetweb/ci/travis/lua_env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 LUAROCKS=ci/lua/bin/luarocks
 eval $($LUAROCKS path --bin)

--- a/lib/util/source/3rd/civetweb/ci/travis/run_ci_tests.sh
+++ b/lib/util/source/3rd/civetweb/ci/travis/run_ci_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ev
 
 source ci/travis/lua_env.sh

--- a/lib/util/source/3rd/libwebp/iosbuild.sh
+++ b/lib/util/source/3rd/libwebp/iosbuild.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This script generates 'WebP.framework' and 'WebPDecoder.framework'. An iOS
 # app can decode WebP images by including 'WebPDecoder.framework' and both

--- a/lib/util/tools/android/build-android.sh
+++ b/lib/util/tools/android/build-android.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/lib/util/tools/android/logcatAllDevices.sh
+++ b/lib/util/tools/android/logcatAllDevices.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2014 Anki, Inc.
 # All rights reserved.
 

--- a/lib/util/tools/branch-scripts/anki-branch-cherrypick.py
+++ b/lib/util/tools/branch-scripts/anki-branch-cherrypick.py
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -z "$1" ]
   then

--- a/lib/util/tools/build/TempCheck.sh
+++ b/lib/util/tools/build/TempCheck.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Brad's command to search for TEMP in code and output a warning. This
 # must be run from the root directory. if the -fail argument is

--- a/lib/util/tools/build/copyBoostHeaders.sh
+++ b/lib/util/tools/build/copyBoostHeaders.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #  copyHeaders.sh
 #
 #  Created by damjan stulic on 4/4/14.

--- a/lib/util/tools/build/copyProdTestData.sh
+++ b/lib/util/tools/build/copyProdTestData.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #  UnitTestBuild.sh
 #  BaseStation

--- a/lib/util/tools/build/copyResources.sh
+++ b/lib/util/tools/build/copyResources.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2014 Anki, Inc.
 # All rights reserved.
 

--- a/lib/util/tools/build/jsonLint/jsonLint.sh
+++ b/lib/util/tools/build/jsonLint/jsonLint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -u

--- a/lib/util/tools/build/mergeStringMaps.sh
+++ b/lib/util/tools/build/mergeStringMaps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2014 Anki, Inc.
 # All rights reserved.
 

--- a/lib/util/tools/build/preBuild.sh
+++ b/lib/util/tools/build/preBuild.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 BUILDDIR=$1
 UNITTEST=$2

--- a/lib/util/tools/build/preBuild_linux.sh
+++ b/lib/util/tools/build/preBuild_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 BUILDDIR=$1
 UNITTEST=$2

--- a/lib/util/tools/build/stringMapBuilder/stringMapBuilder.sh
+++ b/lib/util/tools/build/stringMapBuilder/stringMapBuilder.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 UNITTEST=$1
 

--- a/lib/util/tools/build/versionGenerator/versionGenerator.sh
+++ b/lib/util/tools/build/versionGenerator/versionGenerator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 VersionFileName=$1
 

--- a/lib/util/tools/simpleperf/inferno.sh
+++ b/lib/util/tools/simpleperf/inferno.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SCRIPTPATH=$(dirname "$0")
 export PYTHONPATH=$SCRIPTPATH:$PYTHONPATH
 python -m inferno.inferno "$@"

--- a/ota/cfw.sh
+++ b/ota/cfw.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "Detecting software state..."
 

--- a/ota/make.sh
+++ b/ota/make.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/platform/config/bin/vic-log-uploader
+++ b/platform/config/bin/vic-log-uploader
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # platform/config/bin/vic-log-uploader
 #

--- a/platform/diagnostics-logger/diagnostics-logger
+++ b/platform/diagnostics-logger/diagnostics-logger
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PATH=$PATH:/usr/sbin:/sbin
 LOG="/var/log/messages"

--- a/project/build-scripts/clean.sh
+++ b/project/build-scripts/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2014 Anki, Inc.
 # All rights reserved.
 set -e

--- a/project/build-scripts/cmake-launch-c.in
+++ b/project/build-scripts/cmake-launch-c.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # source: https://crascit.com/2016/04/09/using-ccache-with-cmake/
 

--- a/project/build-scripts/cmake-launch-cxx.in
+++ b/project/build-scripts/cmake-launch-cxx.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # source: https://crascit.com/2016/04/09/using-ccache-with-cmake/
 

--- a/project/build-scripts/create-audio-assets-pr.sh
+++ b/project/build-scripts/create-audio-assets-pr.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Get latest SVN revision from cozmosoundbanks, open Pull-Request for new clad files
 #

--- a/project/build-scripts/exportCSharpClad.sh
+++ b/project/build-scripts/exportCSharpClad.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2014 Anki, Inc.
 # All rights reserved.
 set -e

--- a/project/build-scripts/update_version.sh
+++ b/project/build-scripts/update_version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 GIT=`which git`
 if [ -z $GIT ];then

--- a/project/build-scripts/upload-to-hockeyapp.sh
+++ b/project/build-scripts/upload-to-hockeyapp.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2014 Anki, Inc.
 # All rights reserved.
 

--- a/project/build-scripts/webots/run-sdk-webots-tests.sh
+++ b/project/build-scripts/webots/run-sdk-webots-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Convience script which will run two steps for automation
 #

--- a/project/build-server/build_env.sh
+++ b/project/build-server/build_env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -u

--- a/project/buildServer/steps/clean.sh
+++ b/project/buildServer/steps/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2014 Anki, Inc.
 # All rights reserved.
 set -e

--- a/project/buildServer/steps/configure.sh
+++ b/project/buildServer/steps/configure.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2014 Anki, Inc.
 # All rights reserved.
 set -e

--- a/project/buildServer/steps/publishLicenses.sh
+++ b/project/buildServer/steps/publishLicenses.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Note: requires environment variables:
 #  SAI_PATH referencing https://github.com/anki/sai-viclicensefile-upload-tool/blob/master/vic-file.py

--- a/project/buildServer/steps/pullRequest.sh
+++ b/project/buildServer/steps/pullRequest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 : ${ANKI_AUTH_TOKEN:=""}

--- a/project/buildServer/steps/zipDeployables.sh
+++ b/project/buildServer/steps/zipDeployables.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 GIT=`which git`
 if [ -z $GIT ]

--- a/project/doxygen/post_doxygen.sh
+++ b/project/doxygen/post_doxygen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 DEPENDENCY_LIBS=(requests beautifulsoup4 lxml)
 

--- a/project/victor/build-victor.sh
+++ b/project/victor/build-victor.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/project/victor/scripts/addr2line.sh
+++ b/project/victor/scripts/addr2line.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ "$#" == "0" ]; then
   echo "Usage: $0 <name of .so> <address> [<address>]"

--- a/project/victor/scripts/build_maya_wwise_plugin.sh
+++ b/project/victor/scripts/build_maya_wwise_plugin.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Properly build Anki Maya Wwise Plugin.
 # Add environment variables to include plugin CMake project

--- a/project/victor/scripts/configure_webots_viz.sh
+++ b/project/victor/scripts/configure_webots_viz.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Go to directory of this script
 SCRIPT_PATH=$(dirname $([ -L $0 ] && echo "$(dirname $0)/$(readlink -n $0)" || echo $0))            

--- a/project/victor/scripts/deploy.sh
+++ b/project/victor/scripts/deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -u

--- a/project/victor/scripts/deploy_build_artifacts.sh
+++ b/project/victor/scripts/deploy_build_artifacts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -u

--- a/project/victor/scripts/dump-syms.sh
+++ b/project/victor/scripts/dump-syms.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -u

--- a/project/victor/scripts/dvt2_fake_factory.sh
+++ b/project/victor/scripts/dvt2_fake_factory.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -u
 

--- a/project/victor/scripts/fetch-build-deps.linux.sh
+++ b/project/victor/scripts/fetch-build-deps.linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 #set -u
 

--- a/project/victor/scripts/fetch-build-deps.mac.sh
+++ b/project/victor/scripts/fetch-build-deps.mac.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -u
 

--- a/project/victor/scripts/fetch-build-deps.sh
+++ b/project/victor/scripts/fetch-build-deps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -u
 

--- a/project/victor/scripts/get-dev-images.sh
+++ b/project/victor/scripts/get-dev-images.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Go to directory of this script
 SCRIPT_PATH=$(dirname $([ -L $0 ] && echo "$(dirname $0)/$(readlink -n $0)" || echo $0))            

--- a/project/victor/scripts/install.sh
+++ b/project/victor/scripts/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -u

--- a/project/victor/scripts/prune-dir.sh
+++ b/project/victor/scripts/prune-dir.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Author: chapados
 # Date: 02/16/2018

--- a/project/victor/scripts/reset-data-collection-robot.sh
+++ b/project/victor/scripts/reset-data-collection-robot.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Get the current date of the local system which we know is accurate.
 # We are going to use this along with other information to indentify

--- a/project/victor/scripts/show-cpu-freq.sh
+++ b/project/victor/scripts/show-cpu-freq.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -u

--- a/project/victor/scripts/stage.sh
+++ b/project/victor/scripts/stage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -u

--- a/project/victor/scripts/systemctl.sh
+++ b/project/victor/scripts/systemctl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -u

--- a/project/victor/scripts/victor_fix_permissions.sh
+++ b/project/victor/scripts/victor_fix_permissions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Fix permissions on robot to match expected values required for access by non-root
 # members of the anki group.

--- a/project/victor/scripts/victor_log.sh
+++ b/project/victor/scripts/victor_log.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -u

--- a/project/victor/scripts/victor_log_lnav.sh
+++ b/project/victor/scripts/victor_log_lnav.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -u

--- a/project/victor/scripts/wipe-dev-images.sh
+++ b/project/victor/scripts/wipe-dev-images.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Get the directory of this script
 SCRIPT_PATH=$(dirname $([ -L $0 ] && echo "$(dirname $0)/$(readlink -n $0)" || echo $0))

--- a/pv_ipc/vic-build.sh
+++ b/pv_ipc/vic-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # for x86_64
 

--- a/reset-viccyware.sh
+++ b/reset-viccyware.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 git reset --hard
 git submodule sync --recursive
 git submodule update --init --force --recursive

--- a/robot/convert_projx_to_uv4.sh
+++ b/robot/convert_projx_to_uv4.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 python ./tools/convert_keil_uv5_to_uv4.py  syscon/sysboot.uvprojx    syscon/sysboot.uvproj
 python ./tools/convert_keil_uv5_to_uv4.py  syscon/syscon.uvprojx      syscon/syscon.uvproj

--- a/robot/fixture/cube/sdk_da1458x/5.0.4/projects/target_apps/prod_test/prod_test_anki_cube/export_uv4.sh
+++ b/robot/fixture/cube/sdk_da1458x/5.0.4/projects/target_apps/prod_test/prod_test_anki_cube/export_uv4.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #clean
 rm -rf Keil_4

--- a/robot/fixture/cube/sdk_da1458x/5.0.4/utilities/uvproj2Makefile/uvproj2Makefile
+++ b/robot/fixture/cube/sdk_da1458x/5.0.4/utilities/uvproj2Makefile/uvproj2Makefile
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 version="1.0"
 

--- a/robot/fixture/stm/fixture_release.sh
+++ b/robot/fixture/stm/fixture_release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$(dirname ${BASH_SOURCE[0]})"
 
 #files, config

--- a/robot/fixture/tools/logparse_cube1.sh
+++ b/robot/fixture/tools/logparse_cube1.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #cd "$(dirname ${BASH_SOURCE[0]})"
 
 #BREIF: parse CUBE fixture logfiles to collect LED data (arrays of current usage)

--- a/robot/fixture/tools/release/helpify
+++ b/robot/fixture/tools/release/helpify
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #command line options:
 debug=0

--- a/robot/fixture/tools/release/update_firmware_package.sh
+++ b/robot/fixture/tools/release/update_firmware_package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #if [ ! -e $adb ]; then echo $adb does not exist; exit 1; fi
 

--- a/robot/fixture/tools/release_tools.sh
+++ b/robot/fixture/tools/release_tools.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$(dirname ${BASH_SOURCE[0]})/release"
 
 #get recursive list of git tracked files in tools/release

--- a/robot/syscon/publickeygen.sh
+++ b/robot/syscon/publickeygen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #Breif: generates build/publickeys.h from bash
 rm -f build/publickeys.h

--- a/robot/vmake.sh
+++ b/robot/vmake.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Set the project folder/project file you want below (e.g., robot/robot.uvproj)
 export PRJ=robot
 cd "${0%/*}"

--- a/simulator/kill_ipcs.sh
+++ b/simulator/kill_ipcs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Tool for clearing shared memory segments that sometimes get orphaned occur when using Webots simulator.
 # If you are see red warning when you start the simulator mentioning some problem about shared memory

--- a/tools/ai/listUsedAnimations.sh
+++ b/tools/ai/listUsedAnimations.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Lists used animation names/groups/triggers, and, if the previous
 # build's artifact is available, reports changes in animation usage

--- a/tools/ai/plotBehaviorTree.sh
+++ b/tools/ai/plotBehaviorTree.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 GIT_PROJ_ROOT=`git rev-parse --show-toplevel`
 

--- a/tools/android/aarUnityRemoval.sh
+++ b/tools/android/aarUnityRemoval.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # this should be invoked by build scripts with the usage:
 # aarUnityRemoval.sh IN-AARFILE OUT-AARFILE

--- a/tools/android/apkSplashScreenFix.sh
+++ b/tools/android/apkSplashScreenFix.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # this should be invoked by build scripts with the usage:
 # apkSplashScreenFix.sh IN-APKFILE OUT-APKFILE

--- a/tools/android/logcatAllDevices.sh
+++ b/tools/android/logcatAllDevices.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2014 Anki, Inc.
 # All rights reserved.
 

--- a/tools/build/build-scripts/build-breakpad.sh
+++ b/tools/build/build-scripts/build-breakpad.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -u

--- a/tools/build/build-scripts/gen-symbols-backtrace.sh
+++ b/tools/build/build-scripts/gen-symbols-backtrace.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -u
 

--- a/tools/build/tools/upload-to-hockeyapp.sh
+++ b/tools/build/tools/upload-to-hockeyapp.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2014 Anki, Inc.
 # All rights reserved.
 

--- a/tools/crash-tools/get-callstack.sh
+++ b/tools/crash-tools/get-callstack.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -u
 

--- a/tools/crash-tools/linux/copyDmpsFromRobot.sh
+++ b/tools/crash-tools/linux/copyDmpsFromRobot.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/tools/crash-tools/linux/copyFullBinariesToVM.sh
+++ b/tools/crash-tools/linux/copyFullBinariesToVM.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/tools/crash-tools/linux/copySymsFromVM.sh
+++ b/tools/crash-tools/linux/copySymsFromVM.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/tools/crash-tools/linux/makeSyms.sh
+++ b/tools/crash-tools/linux/makeSyms.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/tools/debug/autoDebugAnim.sh
+++ b/tools/debug/autoDebugAnim.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 

--- a/tools/debug/autoDebugEngine.sh
+++ b/tools/debug/autoDebugEngine.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 

--- a/tools/debug/openCurrLog.sh
+++ b/tools/debug/openCurrLog.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 

--- a/tools/debug/tailCurrLog.sh
+++ b/tools/debug/tailCurrLog.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 

--- a/tools/gyp/test/copies/gyptest-attribs.py
+++ b/tools/gyp/test/copies/gyptest-attribs.py
@@ -33,7 +33,7 @@ test.build('copies-attribs.gyp', chdir='src')
 if sys.platform != 'win32':
   out_path = test.built_file_path('executable-file.sh', chdir='src')
   test.must_contain(out_path,
-                    '#!/bin/bash\n'
+                    '#!/usr/bin/env bash\n'
                     '\n'
                     'echo echo echo echo cho ho o o\n')
   check_attribs('executable-file.sh', expected_exec_bit=stat.S_IXUSR)

--- a/tools/gyp/test/copies/src/executable-file.sh
+++ b/tools/gyp/test/copies/src/executable-file.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo echo echo echo cho ho o o

--- a/tools/gyp/test/mac/bundle-resources/change.sh
+++ b/tools/gyp/test/mac/bundle-resources/change.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 tr a-z A-Z < "${1}" > "${2}"

--- a/tools/gyp/test/mac/bundle-resources/executable-file.sh
+++ b/tools/gyp/test/mac/bundle-resources/executable-file.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo echo echo echo cho ho o o

--- a/tools/gyp/test/mac/gyptest-bundle-resources.py
+++ b/tools/gyp/test/mac/gyptest-bundle-resources.py
@@ -43,7 +43,7 @@ if sys.platform == 'darwin':
 
   test.built_file_must_match(
       'resource.app/Contents/Resources/executable-file.sh',
-      '#!/bin/bash\n'
+      '#!/usr/bin/env bash\n'
       '\n'
       'echo echo echo echo cho ho o o\n', chdir=CHDIR)
 

--- a/tools/gyp/test/mac/postbuild-copy-bundle/postbuild-copy-framework.sh
+++ b/tools/gyp/test/mac/postbuild-copy-bundle/postbuild-copy-framework.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/tools/gyp/test/mac/postbuild-defaults/postbuild-defaults.sh
+++ b/tools/gyp/test/mac/postbuild-defaults/postbuild-defaults.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/tools/gyp/test/mac/postbuild-fail/touch-dynamic.sh
+++ b/tools/gyp/test/mac/postbuild-fail/touch-dynamic.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2011 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/tools/gyp/test/mac/postbuild-fail/touch-static.sh
+++ b/tools/gyp/test/mac/postbuild-fail/touch-static.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2011 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/tools/gyp/test/mac/postbuild-multiple-configurations/postbuild-touch-file.sh
+++ b/tools/gyp/test/mac/postbuild-multiple-configurations/postbuild-touch-file.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/tools/gyp/test/mac/postbuild-static-library/postbuild-touch-file.sh
+++ b/tools/gyp/test/mac/postbuild-static-library/postbuild-touch-file.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/tools/gyp/test/mac/postbuilds/copy.sh
+++ b/tools/gyp/test/mac/postbuilds/copy.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cp "$@"

--- a/tools/gyp/test/mac/postbuilds/script/shared_library_postbuild.sh
+++ b/tools/gyp/test/mac/postbuilds/script/shared_library_postbuild.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2011 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/tools/gyp/test/mac/postbuilds/script/static_library_postbuild.sh
+++ b/tools/gyp/test/mac/postbuilds/script/static_library_postbuild.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2011 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/tools/gyp/test/mac/rebuild/delay-touch.sh
+++ b/tools/gyp/test/mac/rebuild/delay-touch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/tools/gyp/test/mac/sdkroot/test_shorthand.sh
+++ b/tools/gyp/test/mac/sdkroot/test_shorthand.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/tools/gyp/test/mac/strip/subdirectory/test_reading_save_file_from_postbuild.sh
+++ b/tools/gyp/test/mac/strip/subdirectory/test_reading_save_file_from_postbuild.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/tools/gyp/test/mac/type_envvars/test_bundle_executable.sh
+++ b/tools/gyp/test/mac/type_envvars/test_bundle_executable.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/tools/gyp/test/mac/type_envvars/test_bundle_loadable_module.sh
+++ b/tools/gyp/test/mac/type_envvars/test_bundle_loadable_module.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/tools/gyp/test/mac/type_envvars/test_bundle_shared_library.sh
+++ b/tools/gyp/test/mac/type_envvars/test_bundle_shared_library.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/tools/gyp/test/mac/type_envvars/test_check_sdkroot.sh
+++ b/tools/gyp/test/mac/type_envvars/test_check_sdkroot.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2014 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/tools/gyp/test/mac/type_envvars/test_nonbundle_executable.sh
+++ b/tools/gyp/test/mac/type_envvars/test_nonbundle_executable.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/tools/gyp/test/mac/type_envvars/test_nonbundle_loadable_module.sh
+++ b/tools/gyp/test/mac/type_envvars/test_nonbundle_loadable_module.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/tools/gyp/test/mac/type_envvars/test_nonbundle_none.sh
+++ b/tools/gyp/test/mac/type_envvars/test_nonbundle_none.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/tools/gyp/test/mac/type_envvars/test_nonbundle_shared_library.sh
+++ b/tools/gyp/test/mac/type_envvars/test_nonbundle_shared_library.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/tools/gyp/test/mac/type_envvars/test_nonbundle_static_library.sh
+++ b/tools/gyp/test/mac/type_envvars/test_nonbundle_static_library.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/tools/gyp/test/mac/unicode-settings/test_bundle_display_name.sh
+++ b/tools/gyp/test/mac/unicode-settings/test_bundle_display_name.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2013 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/tools/gyp/test/variables/commands/update_golden
+++ b/tools/gyp/test/variables/commands/update_golden
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (c) 2009 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/tools/installLibimobiledevice.command
+++ b/tools/installLibimobiledevice.command
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 sudo pwd
 
 mkdir ~/libimobiledeviceinstall

--- a/tools/json/checkResourceJson.sh
+++ b/tools/json/checkResourceJson.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ROOT_DIR='.'
 

--- a/tools/perfmetric/autoPerfMetric.sh
+++ b/tools/perfmetric/autoPerfMetric.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -u
 

--- a/tools/sdk/vector-python-sdk-private/release-tools/build-release.sh
+++ b/tools/sdk/vector-python-sdk-private/release-tools/build-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script will checkout the repo to a temporary directory
 # and update version numbers ready for release.

--- a/tools/sdk/vector-python-sdk-private/sdk/examples/scripts/take_control.command
+++ b/tools/sdk/vector-python-sdk-private/sdk/examples/scripts/take_control.command
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This file is provided as a convenience for initiating reserved behavior
 # control for SDK scripts.  Mac users can double-click on this file in
 # the Finder to open a Terminal window and execute a Python script so

--- a/tools/smartling/bash/common.sh
+++ b/tools/smartling/bash/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 script_dir="$(dirname "$0")"
 source "$script_dir/settings.sh"

--- a/tools/smartling/bash/delete.sh
+++ b/tools/smartling/bash/delete.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 script_dir="$(dirname "$0")"
 source "$script_dir/common.sh"

--- a/tools/smartling/bash/download-glossary.sh
+++ b/tools/smartling/bash/download-glossary.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 script_dir="$(dirname "$0")"
 source "$script_dir/common.sh"

--- a/tools/smartling/bash/download-tmx.sh
+++ b/tools/smartling/bash/download-tmx.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 script_dir="$(dirname "$0")"
 source "$script_dir/common.sh"

--- a/tools/smartling/bash/download.sh
+++ b/tools/smartling/bash/download.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 script_dir="$(dirname "$0")"
 source "$script_dir/common.sh"

--- a/tools/smartling/bash/globals.sh
+++ b/tools/smartling/bash/globals.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # see https://docs.smartling.com/display/docs/Files+API#FilesAPI-/file/list(GET)
 SUPPORTED_CONDITIONS=(haveAtLeastOneUnapproved haveAtLeastOneApproved haveAtLeastOneTranslated haveAllTranslated haveAllApproved haveAllUnapproved)

--- a/tools/smartling/bash/settings.sh
+++ b/tools/smartling/bash/settings.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # change this value to your "Project Id" found on the Project Settings -> API page in dashboard
 

--- a/tools/smartling/bash/upload.sh
+++ b/tools/smartling/bash/upload.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 script_dir="$(dirname "$0")"
 source "$script_dir/common.sh"

--- a/tools/smartling/build-steps/slack-smartling-pull.sh
+++ b/tools/smartling/build-steps/slack-smartling-pull.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Download strings files from smartling using buildbot and open Pull Request
 #

--- a/tools/smartling/build-steps/slack-smartling-push.sh
+++ b/tools/smartling/build-steps/slack-smartling-push.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Upload strings files to smartling using buildbot
 #

--- a/tools/smartling/smartling-pull.sh
+++ b/tools/smartling/smartling-pull.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Download translated strings files from smartling
 #

--- a/tools/smartling/smartling-push.sh
+++ b/tools/smartling/smartling-push.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Upload string files to Smartling
 #

--- a/tools/versionGenerator/versionGenerator.sh
+++ b/tools/versionGenerator/versionGenerator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 VersionFileName=$1
 

--- a/update-viccyware.sh
+++ b/update-viccyware.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 git pull
 cd EXTERNALS
 git checkout viccyware

--- a/wire/cbd.sh
+++ b/wire/cbd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
This increases compatibility for development with operating systems such as NixOS that do not keep bash at `/bin/bash`.

Many scripts in this repository (696 according to GitHub) already use `#!/usr/bin/env` as part of the shebang, this is just updating the 168 bash scripts using a `#!/bin/bash` shebang to match.